### PR TITLE
Add CachedIterable.from

### DIFF
--- a/src/cached_async_iterable.mjs
+++ b/src/cached_async_iterable.mjs
@@ -1,10 +1,12 @@
+import CachedIterable from "./cached_iterable.mjs";
+
 /*
  * CachedAsyncIterable caches the elements yielded by an async iterable.
  *
  * It can be used to iterate over an iterable many times without depleting the
  * iterable.
  */
-export default class CachedAsyncIterable {
+export default class CachedAsyncIterable extends CachedIterable {
     /**
      * Create an `CachedAsyncIterable` instance.
      *
@@ -12,6 +14,8 @@ export default class CachedAsyncIterable {
      * @returns {CachedAsyncIterable}
      */
     constructor(iterable) {
+        super();
+
         if (Symbol.asyncIterator in Object(iterable)) {
             this.iterator = iterable[Symbol.asyncIterator]();
         } else if (Symbol.iterator in Object(iterable)) {
@@ -19,8 +23,6 @@ export default class CachedAsyncIterable {
         } else {
             throw new TypeError("Argument must implement the iteration protocol.");
         }
-
-        this.seen = [];
     }
 
     /**

--- a/src/cached_async_iterable.mjs
+++ b/src/cached_async_iterable.mjs
@@ -32,15 +32,15 @@ export default class CachedAsyncIterable extends CachedIterable {
      * cached elements of the original (async or sync) iterable.
      */
     [Symbol.iterator]() {
-        const {seen} = this;
+        const cached = this;
         let cur = 0;
 
         return {
             next() {
-                if (seen.length === cur) {
+                if (cached.length === cur) {
                     return {value: undefined, done: true};
                 }
-                return seen[cur++];
+                return cached[cur++];
             }
         };
     }
@@ -54,15 +54,15 @@ export default class CachedAsyncIterable extends CachedIterable {
      * iterable.
      */
     [Symbol.asyncIterator]() {
-        const { seen, iterator } = this;
+        const cached = this;
         let cur = 0;
 
         return {
             async next() {
-                if (seen.length <= cur) {
-                    seen.push(await iterator.next());
+                if (cached.length <= cur) {
+                    cached.push(await cached.iterator.next());
                 }
-                return seen[cur++];
+                return cached[cur++];
             }
         };
     }
@@ -74,15 +74,14 @@ export default class CachedAsyncIterable extends CachedIterable {
      * @param {number} count - number of elements to consume
      */
     async touchNext(count = 1) {
-        const { seen, iterator } = this;
         let idx = 0;
         while (idx++ < count) {
-            if (seen.length === 0 || seen[seen.length - 1].done === false) {
-                seen.push(await iterator.next());
+            if (this.length === 0 || this[this.length - 1].done === false) {
+                this.push(await this.iterator.next());
             }
         }
         // Return the last cached {value, done} object to allow the calling
         // code to decide if it needs to call touchNext again.
-        return seen[seen.length - 1];
+        return this[this.length - 1];
     }
 }

--- a/src/cached_iterable.mjs
+++ b/src/cached_iterable.mjs
@@ -1,17 +1,7 @@
 /*
  * Base CachedIterable class.
  */
-export default class CachedIterable {
-    /**
-     * Create an `CachedIterable` instance.
-     *
-     * @param {Iterable} iterable
-     * @returns {CachedIterable}
-     */
-    constructor() {
-        this.seen = [];
-    }
-
+export default class CachedIterable extends Array {
     /**
      * Create a `CachedIterable` instance from an iterable or, if another
      * instance of `CachedIterable` is passed, return it without any

--- a/src/cached_iterable.mjs
+++ b/src/cached_iterable.mjs
@@ -1,0 +1,30 @@
+/*
+ * Base CachedIterable class.
+ */
+export default class CachedIterable {
+    /**
+     * Create an `CachedIterable` instance.
+     *
+     * @param {Iterable} iterable
+     * @returns {CachedIterable}
+     */
+    constructor() {
+        this.seen = [];
+    }
+
+    /**
+     * Create a `CachedIterable` instance from an iterable or, if another
+     * instance of `CachedIterable` is passed, return it without any
+     * modifications.
+     *
+     * @param {Iterable} iterable
+     * @returns {CachedIterable}
+     */
+    static from(iterable) {
+        if (iterable instanceof this) {
+            return iterable;
+        }
+
+        return new this(iterable);
+    }
+}

--- a/src/cached_sync_iterable.mjs
+++ b/src/cached_sync_iterable.mjs
@@ -24,15 +24,15 @@ export default class CachedSyncIterable extends CachedIterable {
     }
 
     [Symbol.iterator]() {
-        const { seen, iterator } = this;
+        const cached = this;
         let cur = 0;
 
         return {
             next() {
-                if (seen.length <= cur) {
-                    seen.push(iterator.next());
+                if (cached.length <= cur) {
+                    cached.push(cached.iterator.next());
                 }
-                return seen[cur++];
+                return cached[cur++];
             }
         };
     }
@@ -44,15 +44,14 @@ export default class CachedSyncIterable extends CachedIterable {
      * @param {number} count - number of elements to consume
      */
     touchNext(count = 1) {
-        const { seen, iterator } = this;
         let idx = 0;
         while (idx++ < count) {
-            if (seen.length === 0 || seen[seen.length - 1].done === false) {
-                seen.push(iterator.next());
+            if (this.length === 0 || this[this.length - 1].done === false) {
+                this.push(this.iterator.next());
             }
         }
         // Return the last cached {value, done} object to allow the calling
         // code to decide if it needs to call touchNext again.
-        return seen[seen.length - 1];
+        return this[this.length - 1];
     }
 }

--- a/src/cached_sync_iterable.mjs
+++ b/src/cached_sync_iterable.mjs
@@ -1,10 +1,12 @@
+import CachedIterable from "./cached_iterable.mjs";
+
 /*
  * CachedSyncIterable caches the elements yielded by an iterable.
  *
  * It can be used to iterate over an iterable many times without depleting the
  * iterable.
  */
-export default class CachedSyncIterable {
+export default class CachedSyncIterable extends CachedIterable {
     /**
      * Create an `CachedSyncIterable` instance.
      *
@@ -12,13 +14,13 @@ export default class CachedSyncIterable {
      * @returns {CachedSyncIterable}
      */
     constructor(iterable) {
+        super();
+
         if (Symbol.iterator in Object(iterable)) {
             this.iterator = iterable[Symbol.iterator]();
         } else {
             throw new TypeError("Argument must implement the iteration protocol.");
         }
-
-        this.seen = [];
     }
 
     [Symbol.iterator]() {

--- a/test/cached_async_iterable_test.js
+++ b/test/cached_async_iterable_test.js
@@ -55,6 +55,22 @@ suite("CachedAsyncIterable", function() {
         });
     });
 
+    suite("from()", function() {
+        test("pass any iterable", async function() {
+            const iterable = CachedAsyncIterable.from([1, 2]);
+            // No cached elements yet.
+            assert.deepEqual([...iterable], []);
+            // Deplete the original iterable.
+            assert.deepEqual(await toArray(iterable), [1, 2]);
+        });
+
+        test("pass another CachedAsyncIterable", function() {
+            const iterable1 = new CachedAsyncIterable([1, 2]);
+            const iterable2 = CachedAsyncIterable.from(iterable1);
+            assert.equal(iterable1, iterable2);
+        });
+    });
+
     suite("sync iteration over cached elements", function(){
         let o1, o2;
 

--- a/test/cached_async_iterable_test.js
+++ b/test/cached_async_iterable_test.js
@@ -186,22 +186,22 @@ suite("CachedAsyncIterable", function() {
 
         test("consumes an element into the cache", async function() {
             const iterable = new CachedAsyncIterable(generateMessages());
-            assert.equal(iterable.seen.length, 0);
+            assert.equal(iterable.length, 0);
             await iterable.touchNext();
-            assert.equal(iterable.seen.length, 1);
+            assert.equal(iterable.length, 1);
         });
 
         test("allows to consume multiple elements into the cache", async function() {
             const iterable = new CachedAsyncIterable(generateMessages());
             await iterable.touchNext();
             await iterable.touchNext();
-            assert.equal(iterable.seen.length, 2);
+            assert.equal(iterable.length, 2);
         });
 
         test("allows to consume multiple elements at once", async function() {
             const iterable = new CachedAsyncIterable(generateMessages());
             await iterable.touchNext(2);
-            assert.equal(iterable.seen.length, 2);
+            assert.equal(iterable.length, 2);
         });
 
         test("stops at the last element", async function() {
@@ -209,10 +209,10 @@ suite("CachedAsyncIterable", function() {
             await iterable.touchNext();
             await iterable.touchNext();
             await iterable.touchNext();
-            assert.equal(iterable.seen.length, 3);
+            assert.equal(iterable.length, 3);
 
             await iterable.touchNext();
-            assert.equal(iterable.seen.length, 3);
+            assert.equal(iterable.length, 3);
         });
 
         test("works on an empty iterable", async function() {
@@ -223,7 +223,7 @@ suite("CachedAsyncIterable", function() {
             await iterable.touchNext();
             await iterable.touchNext();
             await iterable.touchNext();
-            assert.equal(iterable.seen.length, 1);
+            assert.equal(iterable.length, 1);
         });
 
         test("iteration for such cache works", async function() {

--- a/test/cached_sync_iterable_test.js
+++ b/test/cached_sync_iterable_test.js
@@ -106,22 +106,22 @@ suite("CachedSyncIterable", function() {
 
         test("consumes an element into the cache", function() {
             const iterable = new CachedSyncIterable([o1, o2]);
-            assert.equal(iterable.seen.length, 0);
+            assert.equal(iterable.length, 0);
             iterable.touchNext();
-            assert.equal(iterable.seen.length, 1);
+            assert.equal(iterable.length, 1);
         });
 
         test("allows to consume multiple elements into the cache", function() {
             const iterable = new CachedSyncIterable([o1, o2]);
             iterable.touchNext();
             iterable.touchNext();
-            assert.equal(iterable.seen.length, 2);
+            assert.equal(iterable.length, 2);
         });
 
         test("allows to consume multiple elements at once", function() {
             const iterable = new CachedSyncIterable([o1, o2]);
             iterable.touchNext(2);
-            assert.equal(iterable.seen.length, 2);
+            assert.equal(iterable.length, 2);
         });
 
         test("stops at the last element", function() {
@@ -129,10 +129,10 @@ suite("CachedSyncIterable", function() {
             iterable.touchNext();
             iterable.touchNext();
             iterable.touchNext();
-            assert.equal(iterable.seen.length, 3);
+            assert.equal(iterable.length, 3);
 
             iterable.touchNext();
-            assert.equal(iterable.seen.length, 3);
+            assert.equal(iterable.length, 3);
         });
 
         test("works on an empty iterable", function() {
@@ -140,7 +140,7 @@ suite("CachedSyncIterable", function() {
             iterable.touchNext();
             iterable.touchNext();
             iterable.touchNext();
-            assert.equal(iterable.seen.length, 1);
+            assert.equal(iterable.length, 1);
         });
 
         test("iteration for such cache works", function() {

--- a/test/cached_sync_iterable_test.js
+++ b/test/cached_sync_iterable_test.js
@@ -40,6 +40,19 @@ suite("CachedSyncIterable", function() {
         });
     });
 
+    suite("from()", function() {
+        test("pass any iterable", function() {
+            const iterable = CachedSyncIterable.from([1, 2]);
+            assert.deepEqual([...iterable], [1, 2]);
+        });
+
+        test("pass another CachedSyncIterable", function() {
+            const iterable1 = new CachedSyncIterable([1, 2]);
+            const iterable2 = CachedSyncIterable.from(iterable1);
+            assert.equal(iterable1, iterable2);
+        });
+    });
+
     suite("sync iteration", function(){
         let o1, o2;
 


### PR DESCRIPTION
The static method `from()` may be used to create new `CachedIterable` instances from other iterables (which is the same as using the constructor) or to re-use existing ones. When an existing instance of `CachedIterable` is passed, `from()` simply returns it, preserving its cached state.

The use-case is `fluent-react` and https://github.com/projectfluent/fluent.js/issues/100.  The `Localization` class by default wraps the iterable of contexts it receives in a CachedAsyncIterable. At the same time, the user of `fluent-react` might want to prefetch some contexts from that iterable before handing it off to `Localization`.

Fixes #2.